### PR TITLE
Custom hostname not working

### DIFF
--- a/esp8266-geigercounter.ino
+++ b/esp8266-geigercounter.ino
@@ -30,7 +30,7 @@ char serialInputHelper[RECV_LINE_SIZE];
 int lastCPM = 0, currentCPM = 0;
 float lastuSv = 0, currentuSv = 0;
 
-char hostname[16];
+char hostname[24];
 
 void setup() {
   delay(3000);
@@ -55,9 +55,9 @@ void setup() {
 
 
 #ifdef HOSTNAME
-  hostname = HOSTNAME;
+  strncpy(hostname, HOSTNAME, sizeof(hostname));
 #else
-  snprintf(hostname, 24, "GEIGERCTR-%X", chipid);
+  snprintf(hostname, sizeof(hostname), "GEIGERCTR-%X", chipid);
 #endif
 
 #ifdef USE_HA_AUTODISCOVERY

--- a/settings.h.example
+++ b/settings.h.example
@@ -15,7 +15,7 @@
 
 #define BAUD_GEIGERCOUNTER 9600
 
-//const char* HOSTNAME = "ESP-GeigerCounter"; //Optional
+//#define HOSTNAME "ESP-GeigerCounter" //Optional
 
 const char* OTA_PASSWORD = "foobar";
 


### PR DESCRIPTION
- Changed `HOSTNAME ` to constant macro definition so it is properly evaluated via `#ifdef` directive.

- Increased max. hostname length to 24 characters.